### PR TITLE
Document scenario file improvements from v0.6.0

### DIFF
--- a/src/content-md/intro/scenarios.md
+++ b/src/content-md/intro/scenarios.md
@@ -52,6 +52,28 @@ steps:
 
 ---
 
+## Tokens
+
+Crank scenarios can include tokens (prefixed/affixed with `{{` and `}}` as a
+way to improve readability, maintainability, and portability of test scenarios.
+
+```yaml
+tokens:
+  testEmail: atommy@example.com
+
+steps:
+- step: The FirstName field on Salesforce Lead {{testEmail}} should be Test
+- step: Delete the {{testEmail}} Salesforce Lead
+```
+
+You can also override tokens at run-time:
+
+```shell-session
+$ crank run scenario.yml --token "testEmail=zjimmy@example.com"
+```
+
+---
+
 ## Non-Scalar Data
 
 Sometimes, a test scenario requires data that cannot easily or concisely be
@@ -62,15 +84,73 @@ In situations like this, you can specify these complex objects on a **data**
 property associated with a given step.
 
 ```yaml
+tokens:
+  test:
+    email: atommy@example.com
+    first: Atoma
+    last: Tommy
+
 steps:
 - step: Given I create a Salesforce Lead
   data:
     lead:
-      Email: test@e.com
-      FirstName: Atoma
-      LastName: Tommy
-- step: Then the FirstName field on Salesforce Lead test@e.com should be Atoma
+      Email: '{{test.email}}'
+      FirstName: '{{test.first}}'
+      LastName: '{{test.last}}'
+- step: Then the FirstName field on Salesforce Lead {{test.email}} should be {{test.first}}
 ```
+
+---
+
+## Retries
+
+It's common for systems tested by Crank to be integrated in asynchronous ways.
+For example, object sync time between a CRM like Salesforce and a MAP like
+Marketo may be non-deterministic (but finite), depending on the exact
+configuration of each system.
+
+By default, `crank run` will execute every step in the `steps` list in
+sequence, one immediately after another; if a step's outcome is not a pass,
+no retry is attempted.
+
+In order to account for asynchronous system integrations, you can use the
+`failAfter` property on a given step. When present, Crank will re-attempt step
+execution after any non-passing outcome for as many seconds as is configured on
+this `failAfter` property.
+
+```yaml
+steps:
+- step: Given I create or update a Marketo Lead
+  data:
+    lead:
+      email: test@e.com
+      firstName: Example
+- step: Then the FirstName field on Salesforce Lead test@e.com should be Example
+  failAfter: 90 # Will retry this step for up to 90s if it does not pass
+```
+
+---
+
+## Explicit Waits
+
+It's also common to configure explicit delays in workflows in the systems that
+Crank is used to test (e.g. waiting a specific amount of time before sending a
+communication to a user).
+
+In these situations, you can use the `waitFor` property on any step to pause
+step execution for a certain number of seconds before proceeding.
+
+```yaml
+steps:
+- waitFor: 60 # Will wait 60s before executing this step
+  step: Then the FirstName field on Salesforce Lead test@e.com should be Example
+```
+
+Note that it's possible `waitFor` can be used in combination with `failAfter`.
+If both are used, a step will wait until after the `waitFor` duration elapses,
+then execute the step; if it does not pass, it will retry the step for up to
+the `failAfter` duration, using the initial step execution as the starting time
+for comparison.
 
 ---
 


### PR DESCRIPTION
Documenting tokens, retries, and waits that were introduced in Crank `v0.6.0`: https://github.com/run-crank/cli/releases/tag/v0.6.0