### PR TITLE
Fix GA Implementaton

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -6,11 +6,10 @@ export const onRouteUpdate = ({ location }) => {
   // wrap inside a timeout to make sure react-helmet is done with it's changes (https://github.com/gatsbyjs/gatsby/issues/9139)
   // reactHelmet is using requestAnimationFrame: https://github.com/nfl/react-helmet/blob/5.2.0/src/HelmetUtils.js#L296-L299
   const sendPageView = () => {
-    const pagePath = location
-      ? location.pathname + location.search + location.hash
-      : undefined
     window.gtag('config', 'UA-75228722-5', {
-      page_path: pagePath,
+      // Standardize page path on just the path part for better pageview
+      // tracking that aggregates all query params under a single page/path.
+      page_path: location ? location.pathname : undefined,
     });
   }
 

--- a/src/components/layout/index.js
+++ b/src/components/layout/index.js
@@ -16,8 +16,9 @@ const TemplateWrapper = ({ children, activeTrail, subTitle, invertHeaderColors }
                   window.dataLayer = window.dataLayer || [];
                   function gtag(){dataLayer.push(arguments);}
                   gtag('js', new Date());
-                
-                  gtag('config', 'UA-75228722-5');
+                  // Initial config/pageview call performed in gatsby-browser.js
+                  // onRouteUpdate() implementation. Works on built version, but
+                  // not in dev.
             `}</script>
         </Helmet>
         <Header invertColors={invertHeaderColors} activeTrail={activeTrail} />


### PR DESCRIPTION
- Stops double-counting the initial pageview.
- Aggregates pageviews under just the path part (no hash or query params).