### PR TITLE
Installing Google Tag Manager

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,6 +3,13 @@ module.exports = {
     title: `Crank - BDD Test Automation for Integrated SaaS`,
   },
   plugins: [
+    {
+      resolve: "gatsby-plugin-google-tagmanager",
+      options: {
+        id: "GTM-5GPV46Z",
+        includeInDevelopment: false,
+      },
+    },
     `gatsby-plugin-react-helmet`,
     `svgo`,
     `gatsby-plugin-sass`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8043,6 +8043,24 @@
         "minimatch": "3.0.4"
       }
     },
+    "gatsby-plugin-google-tagmanager": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-tagmanager/-/gatsby-plugin-google-tagmanager-3.7.0.tgz",
+      "integrity": "sha512-c8PyUBxHMoiHl56pNgMB/Am1oW7t1NP7/WJPXJlJ9SkYnv0h61t9xX0GIGK89VVnlEDtPtpH9IItdFMS59v6EA==",
+      "requires": {
+        "@babel/runtime": "^7.14.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.14.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+          "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "gatsby-plugin-page-creator": {
       "version": "2.3.16",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.3.16.tgz",
@@ -15820,8 +15838,7 @@
     "regenerator-runtime": {
       "version": "0.13.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-      "dev": true
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
     },
     "regenerator-transform": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "compression": "^1.7.3",
     "debug": "^4.1.1",
     "express": "^4.16.4",
+    "gatsby-plugin-google-tagmanager": "^3.7.0",
     "github-slugger": "^1.2.1",
     "helmet": "^3.15.0",
     "jquery": "^3.4.1",


### PR DESCRIPTION
Installing Google Tag Manager as requested on [User Story 3530](https://automatoninc.visualstudio.com/Automatest/_sprints/backlog/Atomatest%20Team/Automatest/Sprint%2083%20-%20Onshore?workitem=3530).

Since this page uses Gatsby.js, I installed gatsby-plugin-google-tag-manager and added the GTM id into gatsby.config.  After this change is deployed, I will need to connect with Adam to get him to test that the tag manager is working.